### PR TITLE
DEV: Green Book: optional normalization of dot codes

### DIFF
--- a/PatentDocument/src/main/java/gov/uspto/parser/dom4j/keyvalue/KvParser.java
+++ b/PatentDocument/src/main/java/gov/uspto/parser/dom4j/keyvalue/KvParser.java
@@ -20,6 +20,7 @@ import gov.uspto.patent.PatentReaderException;
 import gov.uspto.patent.model.Patent;
 
 public abstract class KvParser implements Dom4j {
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(KvParser.class);
 
 	private final KvReader kvReader;
@@ -27,6 +28,10 @@ public abstract class KvParser implements Dom4j {
 	public KvParser() {
 		kvReader = new KvReader();
 	}
+
+    public KvParser(final KvReader reader) {
+        kvReader = Preconditions.checkNotNull(reader);
+    }
 
 	public KvParser(Collection<String> maintainSpaceFields, Collection<String> paragraphFields,
 			Collection<String> headerFields, Collection<String> tableFields) {

--- a/PatentDocument/src/main/java/gov/uspto/parser/dom4j/keyvalue/KvReader.java
+++ b/PatentDocument/src/main/java/gov/uspto/parser/dom4j/keyvalue/KvReader.java
@@ -144,7 +144,7 @@ public class KvReader {
                 	tCount++;
                 }
 
-               	field.setText(kv.getValue());
+                genXmlValue(field, kv);
                 currentSection.add(field);
             }
         }
@@ -177,7 +177,7 @@ public class KvReader {
                 currentSection = DocumentHelper.createElement(kv.getKey());
             } else {
                 Element field = DocumentHelper.createElement(kv.getKey());
-                field.setText(kv.getValue());
+                genXmlValue(field, kv);
                 currentSection.add(field);
             }
         }
@@ -242,11 +242,11 @@ public class KvReader {
                     currentSection = DocumentHelper.createElement(currentFieldGroup.getName());
 
                     Element field = DocumentHelper.createElement(kv.getKey());
-                    field.setText(kv.getValue());
+                    genXmlValue(field, kv);
                     currentSection.add(field);
                 } else {                    
                     Element field = DocumentHelper.createElement(kv.getKey());
-                    field.setText(kv.getValue());
+                    genXmlValue(field, kv);
                     currentSection.add(field);
                 }
             }
@@ -263,12 +263,12 @@ public class KvReader {
                 currentSection = DocumentHelper.createElement(currentFieldGroup.getName());
 
                 Element field = DocumentHelper.createElement(kv.getKey());
-                field.setText(kv.getValue());
+                genXmlValue(field, kv);
                 currentSection.add(field);
 
             } else if (currentFieldGroup == entry.getFieldGroup() && currentSection != rootNode) {
                 Element field = DocumentHelper.createElement(kv.getKey());
-                field.setText(kv.getValue());
+                genXmlValue(field, kv);
                 currentSection.add(field);
             } else {
                 if (currentSection != rootNode) {
@@ -278,7 +278,7 @@ public class KvReader {
                 currentSection = rootNode;
 
                 Element field = DocumentHelper.createElement(kv.getKey());
-                field.setText(kv.getValue());
+                genXmlValue(field, kv);
                 currentSection.add(field);
             }
         }
@@ -307,7 +307,7 @@ public class KvReader {
                 // String[] parts = processLineRegex(currentLine);
                 String[] parts = processLineLeadingWhiteSpace(currentLine);
                 if (parts.length == 2) {
-                    keyValues.add(new KeyValue(parts[0], parts[1]));
+                    keyValues.add(new KeyValue(parts[0], normalizeValue(parts[1])));
                     // } else if (sections != null && parts.length == 1 &&
                     // sections.contains(parts[0])) {
                     // keyValues.add(new KeyValue(parts[0], ""));
@@ -319,7 +319,7 @@ public class KvReader {
                     }
                     int lastLoc = keyValues.size() - 1;
                     KeyValue lastKv = keyValues.get(lastLoc);
-                    lastKv.appendValue(parts[0]);
+                    lastKv.appendValue(normalizeValue(parts[0]));
                     currentFieldName = lastKv.getKey().toUpperCase();
                 }
             }
@@ -329,6 +329,48 @@ public class KvReader {
         }
 
         return keyValues;
+    }
+
+    /**
+     * Generate the XML representation of the given value, and add it to the given
+     * XML element
+     * 
+     * @param element
+     *            the element to which the XML representation should be added
+     * @param value
+     *            the value to transform into XML
+     */
+    protected void genXmlValue(final Element element, final String value) {
+        element.setText(value);
+    }
+
+    /**
+     * Normalize a {@link KeyValue}'s value
+     * 
+     * <p>
+     * The default implementation merely returns its argument. This method should be
+     * overridden to customize the reader's behavior.
+     * 
+     * @param string
+     *            the string to normalize
+     * @return the normalized string
+     */
+    protected String normalizeValue(final String string) {
+        return string;
+    }
+
+    /**
+     * Generate the XML representation of the given {@link KeyValue}'s value, and
+     * add it to the given XML element
+     * 
+     * @param element
+     *            the element to which the XML representation should be added
+     * @param keyValue
+     *            the {@link KeyValue} to transform into XML
+     * @see KvReader#genXmlValue(Element, String)
+     */
+    private void genXmlValue(final Element element, final KeyValue keyValue) {
+        genXmlValue(element, keyValue.getValue());
     }
 
     /**

--- a/PatentDocument/src/main/java/gov/uspto/patent/doc/greenbook/Greenbook.java
+++ b/PatentDocument/src/main/java/gov/uspto/patent/doc/greenbook/Greenbook.java
@@ -65,9 +65,18 @@ public class Greenbook extends KvParser {
 	private static List<String> HEADER_FIELDS = Arrays.asList(new String[] { "PAC" });
 	private static List<String> TABLE_FIELDS = Arrays.asList(new String[] { "TBL" });
 
-	public Greenbook() {
-		super(MAINTAIN_SPACE_FIELDS, PARAGRAPH_FIELDS, HEADER_FIELDS, TABLE_FIELDS);
-	}
+    public Greenbook() {
+        this(false);
+    }
+
+    /**
+     * @param normalize
+     *            whether {@link DotCodes} should be replaced by their Unicode or
+     *            XML equivalents
+     */
+    public Greenbook(final boolean normalize) {
+        super(newKvReader(normalize));
+    }
 
 	/*
 	 * private static final Set<String> SECTIONS = new HashSet<String>(20);
@@ -225,5 +234,12 @@ public class Greenbook extends KvParser {
 			System.out.println(patent.toString());
 		}
 	}
+
+    private static GreenbookKvReader newKvReader(final boolean normalize) {
+        final GreenbookKvReader kvReader = new GreenbookKvReader(normalize);
+        kvReader.setMaintainSpaceFields(MAINTAIN_SPACE_FIELDS);
+        kvReader.setFieldsForId(PARAGRAPH_FIELDS, HEADER_FIELDS, TABLE_FIELDS);
+        return kvReader;
+    }
 
 }

--- a/PatentDocument/src/main/java/gov/uspto/patent/doc/greenbook/GreenbookKvReader.java
+++ b/PatentDocument/src/main/java/gov/uspto/patent/doc/greenbook/GreenbookKvReader.java
@@ -1,0 +1,70 @@
+package gov.uspto.patent.doc.greenbook;
+
+import java.io.StringReader;
+
+import org.dom4j.Document;
+import org.dom4j.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import gov.uspto.parser.dom4j.keyvalue.KvReader;
+import gov.uspto.patent.PatentReader;
+import gov.uspto.patent.PatentReaderException;
+
+/**
+ * A {@link KvReader} implementation providing optional normalization of {@link DotCodes}.
+ * 
+ * @see <a href="https://github.com/USPTO/PatentPublicData/issues/59">https://github.com/USPTO/PatentPublicData/issues/59</a>
+ * 
+ * @author Luc Boruta (luc@thunken.com)
+ */
+public class GreenbookKvReader extends KvReader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GreenbookKvReader.class);
+
+    private final boolean normalize;
+
+    public GreenbookKvReader() {
+        this(false);
+    }
+
+    /**
+     * @param normalize
+     *            whether {@link DotCodes} should be replaced by their Unicode or
+     *            XML equivalents
+     */
+    public GreenbookKvReader(final boolean normalize) {
+        this.normalize = normalize;
+    }
+
+    @Override
+    protected void genXmlValue(final Element element, final String value) {
+        Document document = null;
+        if (normalize && value != null) {
+            final String normalized = DotCodes.replaceSubSupHTML(value);
+            if (!normalized.equals(value)) {
+                /*
+                 * Wrap a dummy <span> around the value, to avoid
+                 * "Content is not allowed in prolog." errors.
+                 */
+                try {
+                    document = PatentReader.getJDOM(new StringReader("<span>" + normalized + "</span>"));
+                } catch (final PatentReaderException e) {
+                    LOGGER.warn("Failed to parse and normalize value");
+                    document = null;
+                }
+            }
+        }
+        if (document == null) {
+            super.genXmlValue(element, value);
+        } else {
+            element.appendContent((Element) document.node(0));
+        }
+    }
+
+    @Override
+    protected String normalizeValue(final String string) {
+        return normalize && string != null ? DotCodes.replace(string) : string;
+    }
+
+}


### PR DESCRIPTION
First PR for #59. (Happy #hacktoberfest!)

This commit provides optional normalization of dot codes in Green Book documents, building upon `gov.uspto.patent.doc.greenbook.DotCodes`. Normalization is disabled by default, so changes are backward-compatible. It can be toggled at various points in the pipeline, including in `PatentReader`, providing a format-independent endpoint for dot codes and the upcoming normalization of "brace codes".

(My fork's master branch includes a handful of commits to reformat the code, organize imports, etc. I know these commits are tedious to review, but let me know if you're interested in merging such changes to clean the codebase.)