### PR TITLE
Handle leading and trailing whitespace in title.

### DIFF
--- a/Common/src/main/java/gov/uspto/common/text/StringCaseUtil.java
+++ b/Common/src/main/java/gov/uspto/common/text/StringCaseUtil.java
@@ -80,7 +80,9 @@ public class StringCaseUtil {
 			return null;
 		} else if (text.isEmpty()) {
 			return text;
-		}
+		} else if (text.trim().isEmpty()) {
+            return text.trim();
+        }
 
 		/*
 		 * If text is not all capitals then maintain capitals
@@ -90,7 +92,11 @@ public class StringCaseUtil {
 			maintainCapitals = true;
 		}
 
-		String[] words = text.split("\\s+");
+        /*
+         * Split on whitespace (after after trimming leading and trailing
+         * whitespace.)
+         */
+		String[] words = text.trim().split("\\s+");
 
 		boolean inBlock = false;
 		char wantCloseBlockChar = '?';


### PR DESCRIPTION
Leading whitespace in the title resulted in
StringIndexOutOfBoundsException when title contained leading whitespace.
Fix by using String.trim() before splitting on whitespace in toTitleCase
method.