### PR TITLE
Fix extraction of continuation relations

### DIFF
--- a/PatentDocument/src/main/java/gov/uspto/patent/doc/sgml/fragments/RelatedIdNode.java
+++ b/PatentDocument/src/main/java/gov/uspto/patent/doc/sgml/fragments/RelatedIdNode.java
@@ -1,6 +1,7 @@
 package gov.uspto.patent.doc.sgml.fragments;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.dom4j.Document;
@@ -77,13 +78,13 @@ public class RelatedIdNode extends DOMFragmentReader<List<DocumentId>> {
 
         if (continuationN != null) {
             Node continueN = continuationN.selectSingleNode("B631");
-            readChildParent(divitionalNodes, DocumentIdType.CONTINUATION);
+            readChildParent(continueN, DocumentIdType.CONTINUATION);
 
             Node continueInPartN = continuationN.selectSingleNode("B632/PARENT-US");
-            readChildParent(divitionalNodes, DocumentIdType.CONTINUATION_IN_PART);
+            readChildParent(continueInPartN, DocumentIdType.CONTINUATION_IN_PART);
 
             Node continueReIssueN = continuationN.selectSingleNode("B633/PARENT-US");
-            readChildParent(divitionalNodes, DocumentIdType.CONTINUATION_REISSUE);
+            readChildParent(continueReIssueN, DocumentIdType.CONTINUATION_REISSUE);
         }
 
         /*
@@ -115,6 +116,12 @@ public class RelatedIdNode extends DOMFragmentReader<List<DocumentId>> {
         }
 
         return docIds;
+    }
+
+    private void readChildParent(Node node, DocumentIdType docIdType) {
+        if (node != null) {
+            readChildParent(Collections.singletonList(node), docIdType);
+        }
     }
 
     private void readChildParent(List<Node> nodes, DocumentIdType docIdType) {

--- a/PatentDocument/src/main/java/gov/uspto/patent/model/DocumentId.java
+++ b/PatentDocument/src/main/java/gov/uspto/patent/model/DocumentId.java
@@ -10,6 +10,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 import gov.uspto.patent.InvalidDataException;
+import org.apache.commons.lang3.builder.CompareToBuilder;
 
 /**
  * Document ID for Patents and Patent Applications
@@ -401,7 +402,11 @@ public class DocumentId implements Comparable<DocumentId> {
 		if (getDate() == null || o.getDate() == null || getDate().getDate() == null || o.getDate().getDate() == null) {
 			return 1;
 		}
-		return getDate().getDate().compareTo(o.getDate().getDate());
+
+		return new CompareToBuilder()
+				.append(getDate().getDate(), o.getDate().getDate())
+				.append(getDocNumber(), o.getDocNumber())
+				.build();
 	}
 
 	@Override

--- a/PatentDocument/src/test/java/gov/uspto/patent/doc/sgml/SgmlTest.java
+++ b/PatentDocument/src/test/java/gov/uspto/patent/doc/sgml/SgmlTest.java
@@ -7,7 +7,11 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import gov.uspto.patent.model.DocumentId;
+import gov.uspto.patent.model.DocumentIdType;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,5 +58,24 @@ public class SgmlTest {
 		Path filePath = samplePath.resolve("US06337117.xml");
 		Patent patent = sgml.parse(filePath.toFile());
 		assertEquals("Multiple Inventors", 5, patent.getInventors().size());
+	}
+
+	@Test
+	public void shouldExtractContinuationRelations() throws PatentReaderException, IOException {
+		Sgml sgml = new Sgml();
+		Path filePath = samplePath.resolve("US06336130.xml");
+		Patent patent = sgml.parse(filePath.toFile());
+		List<String> continuationDocNumbers =
+				patent.getRelationIds().stream()
+						.filter(r -> r.getType() == DocumentIdType.CONTINUATION)
+						.map(DocumentId::getDocNumber)
+						.collect(Collectors.toList());
+		assertEquals("Continuations not extracted", 2, continuationDocNumbers.size());
+		assertTrue(
+				"Continuation child missing from " + continuationDocNumbers,
+				continuationDocNumbers.contains("9413215"));
+		assertTrue(
+				"Continuation parent missing from " + continuationDocNumbers,
+				continuationDocNumbers.contains("PCTNO9800107"));
 	}
 }


### PR DESCRIPTION
Continuation relations were missed because of what looks like a copy and paste error.

Also fixed DocumentId.compareTo() so that DocumentIds with the same date can be added to a TreeSet.

Just as an aside, there doesn't seem to be any way to distinguish between parent and child relations once they've been extracted into the List. I don't know how important that is to others. I've modified the code we're using to use a `Relation` class which has parent and child document ID fields, so we know which is which.

I don't know if you have a JVM level that you're adhering to. I've used some Java 8 features (just in the test).