### PR TITLE
Update StringCaseUtil.java

### DIFF
--- a/Common/src/main/java/gov/uspto/common/text/StringCaseUtil.java
+++ b/Common/src/main/java/gov/uspto/common/text/StringCaseUtil.java
@@ -127,6 +127,7 @@ public class StringCaseUtil {
 			/*
 			 * Block Quoted or Bracketed; maintain original lettercase.
 			 */
+			if(words[i].length() == 0) continue;
 			char firstChar = words[i].charAt(0);
 			char lastChar = words[i].charAt(words[i].length()-1);
 			if (('\u2018' == firstChar && '\u2019' == lastChar) || '(' == firstChar && ')' == lastChar || (')' == lastChar && !inBlock)) {


### PR DESCRIPTION
When parsing ipg180206.zip, encountered a zero length word which triggered an index-out-of-bounds exception.  Change continues the for loop before the call to charAt(0) if the word has zero length.