### PR TITLE
fix java.lang.StringIndexOutOfBoundsException when chinese company name starts with parentheses

### DIFF
--- a/PatentDocument/src/main/java/gov/uspto/patent/OrgSynonymGenerator.java
+++ b/PatentDocument/src/main/java/gov/uspto/patent/OrgSynonymGenerator.java
@@ -358,7 +358,7 @@ public class OrgSynonymGenerator {
 	protected void chineseCompanyNames(NameOrg name){
 		for(String nameStr: name.getSynonyms()) {
 			int beginIdx = nameStr.indexOf('(');
-			if (beginIdx != -1) {
+			if (beginIdx > 0) { // Only process further if location is not at beginning of text, otherwise we can't extract the company name
 				int endIdx = nameStr.indexOf(')');
 				if (endIdx != -1) {
 					String bracketWord = nameStr.substring(beginIdx+1, endIdx);

--- a/PatentDocument/src/test/java/gov/uspto/patent/OrgSynonymGeneratorTest.java
+++ b/PatentDocument/src/test/java/gov/uspto/patent/OrgSynonymGeneratorTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import gov.uspto.patent.model.CountryCode;
@@ -233,6 +234,20 @@ public class OrgSynonymGeneratorTest {
 		}		
 	}
 	
+	@Test 
+	public void ChineseCompanyNamesShouldNotCrashOnStartingWithParentheses() {				
+		OrgSynonymGenerator generator = new OrgSynonymGenerator();
+
+		String nameText = "(SHENZHEN) COMPANY, LIMITED";
+		NameOrg name = new NameOrg(nameText);
+		name.addSynonymNorm(nameText);
+		try {
+			generator.chineseCompanyNames(name);
+		} catch(StringIndexOutOfBoundsException e) {
+			Assert.fail("chineseCompanyNames threw StringIndexOutOfBoundsException: " + e.getMessage());
+		}
+	}
+
 	private List<String> missingSynonyms(NameOrg name, List<String> expect) {
 		List<String> missing = new ArrayList<String>();
 		for(String expectItem: expect) {


### PR DESCRIPTION
Fixes https://github.com/USPTO/PatentPublicData/issues/125.

This was caused by a chinese company name of the form:

```
(SHENZHEN) COMPANY, LIMITED
```
The method that tries to parse out the company name before the city part in parentheses fails, because it is at the beginning of the string (the actual company name seems missing).

Fixed it by skipping the company name parsing if this is the case and included a unit test for this.